### PR TITLE
Plug memory leaks by eliminating StEmcPosition ptrs.

### DIFF
--- a/StAnMaker.cxx
+++ b/StAnMaker.cxx
@@ -545,7 +545,7 @@ void StAnMaker::RunTowers()
   // looping over clusters - STAR: matching already done
   // get # of clusters and set variables
   unsigned int nBEmcPidTraits = mPicoDst->numberOfBEmcPidTraits();
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // loop over ALL clusters in PicoDst and add to jet //TODO
   for(unsigned short iClus = 0; iClus < nBEmcPidTraits; iClus++){
@@ -561,7 +561,7 @@ void StAnMaker::RunTowers()
 
     // cluster and tower position - from vertex and ID
     StThreeVectorF  towPosition;
-    towPosition = mPosition->getPosFromVertex(mVertex, towID);
+    towPosition = mPosition.getPosFromVertex(mVertex, towID);
     double towPhi = towPosition.phi();
     double towEta = towPosition.pseudoRapidity();
 
@@ -584,7 +584,7 @@ void StAnMaker::RunTowers()
     if(towerID < 0) continue; // double check these aren't still in the event list
 
     // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-    StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+    StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
     double towerPhi = towerPosition.phi();
     double towerEta = towerPosition.pseudoRapidity();
     int towerADC = tower->adc();

--- a/StJetFrameworkPicoBase.cxx
+++ b/StJetFrameworkPicoBase.cxx
@@ -1256,7 +1256,7 @@ Bool_t StJetFrameworkPicoBase::CheckForHT(int RunFlag, int type) {
 //________________________________________________________________________________________________________
 Bool_t StJetFrameworkPicoBase::GetMomentum(StThreeVectorF &mom, const StPicoBTowHit* tower, Double_t mass, StPicoEvent *PicoEvent) const {
   // initialize Emc position objects
-  StEmcPosition *Position = new StEmcPosition();
+  StEmcPosition Position;
 
   // vertex components
   StThreeVectorF fVertex = PicoEvent->primaryVertex();
@@ -1271,7 +1271,7 @@ Bool_t StJetFrameworkPicoBase::GetMomentum(StThreeVectorF &mom, const StPicoBTow
   int towerID = tower->id();
 
   // get tower position
-  StThreeVectorF towerPosition = Position->getPosFromVertex(fVertex, towerID);
+  StThreeVectorF towerPosition = Position.getPosFromVertex(fVertex, towerID);
   double posX = towerPosition.x();
   double posY = towerPosition.y();
   double posZ = towerPosition.z();

--- a/StJetMakerTask.cxx
+++ b/StJetMakerTask.cxx
@@ -687,7 +687,7 @@ void StJetMakerTask::FindJets()
   fFull_Event.clear();
 
   // initialize Emc position objects
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // assume neutral pion mass
   // additional parameters constructed
@@ -802,7 +802,7 @@ void StJetMakerTask::FindJets()
       if(towerID < 0) continue; // double check these aren't still in the event list
 
       // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-      StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+      StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
       double towerPhi = towerPosition.phi();
       if(towerPhi < 0)    towerPhi += 2.0*pi;
       if(towerPhi > 2*pi) towerPhi -= 2.0*pi;
@@ -975,7 +975,7 @@ void StJetMakerTask::FillJetConstituents(StJet *jet, std::vector<fastjet::Pseudo
   double pi0mass = Pico::mMass[0]; // GeV
 
   // get EMCal position
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // initially set track and cluster constituent sizes
   jet->SetNumberOfTracks(constituents.size());
@@ -1045,7 +1045,7 @@ void StJetMakerTask::FillJetConstituents(StJet *jet, std::vector<fastjet::Pseudo
 
         // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
         int towerID = tower->id();
-        StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+        StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
         double towerPhi = towerPosition.phi();
         double towerEta = towerPosition.pseudoRapidity();
         double towEuncorr = tower->energy();
@@ -1300,7 +1300,7 @@ Bool_t StJetMakerTask::AcceptJetTrack(StPicoTrack *trk, Float_t B, StThreeVector
 //________________________________________________________________________
 Bool_t StJetMakerTask::AcceptJetTower(StPicoBTowHit *tower) {
   // get EMCal position
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // constants:
   double pi = 1.0*TMath::Pi();
@@ -1312,7 +1312,7 @@ Bool_t StJetMakerTask::AcceptJetTower(StPicoBTowHit *tower) {
   if(towerID < 0) return kFALSE; 
 
   // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-  StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+  StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
   double phi = towerPosition.phi();
   if(phi < 0)    phi += 2.0*pi;
   if(phi > 2*pi) phi -= 2.0*pi;
@@ -1456,7 +1456,7 @@ Bool_t StJetMakerTask::SelectAnalysisCentralityBin(Int_t centbin, Int_t fCentral
 //________________________________________________________________________________________________________
 Bool_t StJetMakerTask::GetMomentum(StThreeVectorF &mom, const StPicoBTowHit* tower, Double_t mass) const {
   // initialize Emc position objects
-  StEmcPosition *Position = new StEmcPosition();
+  StEmcPosition Position;
 
   // vertex components - only need if below method is used
   // mGeom3->getEtaPhi(towerID,tEta,tPhi);
@@ -1471,7 +1471,7 @@ Bool_t StJetMakerTask::GetMomentum(StThreeVectorF &mom, const StPicoBTowHit* tow
   int towerID = tower->id();
 
   // get tower position
-  StThreeVectorF towerPosition = Position->getPosFromVertex(mVertex, towerID);
+  StThreeVectorF towerPosition = Position.getPosFromVertex(mVertex, towerID);
   double posX = towerPosition.x();
   double posY = towerPosition.y();
   double posZ = towerPosition.z();

--- a/StJetMakerTaskBGsub.cxx
+++ b/StJetMakerTaskBGsub.cxx
@@ -672,7 +672,7 @@ void StJetMakerTaskBGsub::FindJets()
   fFull_Event.clear();
 
   // initialize Emc position objects
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // assume neutral pion mass
   // additional parameters constructed
@@ -763,7 +763,7 @@ void StJetMakerTaskBGsub::FindJets()
       if(towerID < 0) continue; // double check these aren't still in the event list
 
       // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-      StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+      StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
       double towerPhi = towerPosition.phi();
       if(towerPhi < 0)    towerPhi += 2.0*pi;
       if(towerPhi > 2*pi) towerPhi -= 2.0*pi;
@@ -916,7 +916,7 @@ void StJetMakerTaskBGsub::FillJetConstituents(StJet *jet, std::vector<fastjet::P
   double pi0mass = Pico::mMass[0]; // GeV
 
   // get EMCal position
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // initially set track and cluster constituent sizes
   jet->SetNumberOfTracks(constituents.size());
@@ -986,7 +986,7 @@ void StJetMakerTaskBGsub::FillJetConstituents(StJet *jet, std::vector<fastjet::P
 
         // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
         int towerID = tower->id();
-        StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+        StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
         double towerPhi = towerPosition.phi();
         double towerEta = towerPosition.pseudoRapidity();
         double towEuncorr = tower->energy();
@@ -1163,7 +1163,7 @@ Bool_t StJetMakerTaskBGsub::AcceptJetTrack(StPicoTrack *trk, Float_t B, StThreeV
 //________________________________________________________________________
 Bool_t StJetMakerTaskBGsub::AcceptJetTower(StPicoBTowHit *tower) {
   // get EMCal position
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // constants:
   double pi = 1.0*TMath::Pi();
@@ -1175,7 +1175,7 @@ Bool_t StJetMakerTaskBGsub::AcceptJetTower(StPicoBTowHit *tower) {
   if(towerID < 0) return kFALSE; 
 
   // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-  StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+  StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
   double phi = towerPosition.phi();
   if(phi < 0)    phi += 2.0*pi;
   if(phi > 2*pi) phi -= 2.0*pi;
@@ -1319,7 +1319,7 @@ Bool_t StJetMakerTaskBGsub::SelectAnalysisCentralityBin(Int_t centbin, Int_t fCe
 //________________________________________________________________________________________________________
 Bool_t StJetMakerTaskBGsub::GetMomentum(StThreeVectorF &mom, const StPicoBTowHit* tower, Double_t mass) const {
   // initialize Emc position objects
-  StEmcPosition *Position = new StEmcPosition();
+  StEmcPosition Position;
 
   // vertex components - only need if below method is used
   // mGeom3->getEtaPhi(towerID,tEta,tPhi);
@@ -1334,7 +1334,7 @@ Bool_t StJetMakerTaskBGsub::GetMomentum(StThreeVectorF &mom, const StPicoBTowHit
   int towerID = tower->id();
 
   // get tower position
-  StThreeVectorF towerPosition = Position->getPosFromVertex(mVertex, towerID);
+  StThreeVectorF towerPosition = Position.getPosFromVertex(mVertex, towerID);
   double posX = towerPosition.x();
   double posY = towerPosition.y();
   double posZ = towerPosition.z();

--- a/StPicoTrackClusterQA.cxx
+++ b/StPicoTrackClusterQA.cxx
@@ -730,8 +730,8 @@ void StPicoTrackClusterQA::RunQA()
   // get # of clusters and set variables
   unsigned int nclus = mPicoDst->numberOfBEmcPidTraits();
   StThreeVectorF  towPosition, clusPosition;
-  StEmcPosition *mPosition = new StEmcPosition();
-  StEmcPosition *mPosition2 = new StEmcPosition();
+  StEmcPosition mPosition;
+  StEmcPosition mPosition2;
 
   // print EMCal cluster info
   if(fDebugLevel == 7) mPicoDst->printBEmcPidTraits();
@@ -755,8 +755,8 @@ void StPicoTrackClusterQA::RunQA()
     if(towID < 0) continue;
 
     // cluster and tower position - from vertex and ID
-    towPosition = mPosition->getPosFromVertex(mVertex, towID);
-    clusPosition = mPosition2->getPosFromVertex(mVertex, clusID);
+    towPosition = mPosition.getPosFromVertex(mVertex, towID);
+    clusPosition = mPosition2.getPosFromVertex(mVertex, clusID);
 
     // index of associated track in the event
     int trackIndex = cluster->trackIndex();
@@ -1011,7 +1011,7 @@ Bool_t StPicoTrackClusterQA::AcceptTrack(StPicoTrack *trk, Float_t B, StThreeVec
 //________________________________________________________________________
 Bool_t StPicoTrackClusterQA::AcceptTower(StPicoBTowHit *tower) {
   // get EMCal position
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // constants:
   double pi = 1.0*TMath::Pi();
@@ -1023,7 +1023,7 @@ Bool_t StPicoTrackClusterQA::AcceptTower(StPicoBTowHit *tower) {
   if(towerID < 0) return kFALSE;
 
   // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-  StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+  StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
   double phi = towerPosition.phi();
   if(phi < 0)    phi += 2.0*pi;
   if(phi > 2*pi) phi -= 2.0*pi;
@@ -1539,7 +1539,7 @@ void StPicoTrackClusterQA::RunTowerTest()
   // set / initialize some variables
   double pi = 1.0*TMath::Pi();
   double pi0mass = Pico::mMass[0]; // GeV
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // towerStatus array
   float mTowerMatchTrkIndex[4801] = { 0 };
@@ -1567,7 +1567,7 @@ void StPicoTrackClusterQA::RunTowerTest()
 
     // cluster and tower position - from vertex and ID
     StThreeVectorF  towPosition;
-    towPosition = mPosition->getPosFromVertex(mVertex, towID);
+    towPosition = mPosition.getPosFromVertex(mVertex, towID);
     double towPhi = towPosition.phi();
     if(towPhi < 0)    towPhi += 2*pi;
     if(towPhi > 2*pi) towPhi -= 2*pi;
@@ -1629,7 +1629,7 @@ void StPicoTrackClusterQA::RunTowerTest()
     if(towerID < 0) continue; // double check these aren't still in the event list
 
     // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-    StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+    StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
     double towerPhi = towerPosition.phi();
     if(towerPhi < 0)    towerPhi += 2*pi;
     if(towerPhi > 2*pi) towerPhi -= 2*pi;
@@ -1700,7 +1700,7 @@ void StPicoTrackClusterQA::RunFiredTriggerQA()
   int nEmcTrigger = mPicoDst->numberOfEmcTriggers();
 
   // initialize Emc position objects
-  StEmcPosition *mPosition = new StEmcPosition();
+  StEmcPosition mPosition;
 
   // loop over valid EmcalTriggers
   for(int i = 0; i < nEmcTrigger; i++) {
@@ -1741,7 +1741,7 @@ void StPicoTrackClusterQA::RunFiredTriggerQA()
     if(towerID < 0) { cout<<"tower ID < 0, tower ID = "<<towerID<<endl; continue; } // double check these aren't still in the event list
 
     // cluster and tower position - from vertex and ID: shouldn't need additional eta correction
-    StThreeVectorF towerPosition = mPosition->getPosFromVertex(mVertex, towerID);
+    StThreeVectorF towerPosition = mPosition.getPosFromVertex(mVertex, towerID);
     //double towerPhi = towerPosition.phi();
     double towerEta = towerPosition.pseudoRapidity();
     double towerE = tower->energy();


### PR DESCRIPTION
Hey Joel,
When looking at a *lot* of tower positions in my code, I finally realized that the 
`StEmcPosition* mPosition = new StEmcPosition` (used to get the position relative to the vertex with `towPosition = mPosition->getPosFromVertex(mVertex, towId)`) idiom that I got from your framework is a leak. I ran a little test on my code, and it is equally correct to either delete the pointers to free the memory or declare objects and not pointers.
I went through and modified your framework to change pointers to objects. I don't have the required libraries downloaded to actually compile your framework, but I think it is all functional.
Thanks for the code and support!
Dave